### PR TITLE
Fixes and improvements to ViewUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.2.0] - 2025-05-27
+
+### Added
+
+- Added script to the new entity form that will reset the form so that browser cache does not populate it when the Back button is used.
+
+### Changed
+
+- Use the ViewUtils methods to add scripts and webjars
+
+### Fixed
+
+- Fixed ClassCastException when adding multiple scripts or webjars to the model
+
 ## [1.1.0] - 2025-04-29
 
 ### Added
@@ -28,3 +42,4 @@ Initial release of code extracted from other projects.
 [unreleased]: https://source.ohsu.edu/OCTRI-Apps/common-lib/compare/v1.0.0...HEAD
 [1.0.0]: https://source.ohsu.edu/OCTRI-Apps/common-lib/releases/tag/v1.0.0
 [1.1.0]: https://source.ohsu.edu/OCTRI-Apps/common-lib/releases/tag/v1.1.0
+[1.2.0]: https://source.ohsu.edu/OCTRI-Apps/common-lib/releases/tag/v1.2.0

--- a/src/main/java/org/octri/common/controller/AbstractBaseEntityController.java
+++ b/src/main/java/org/octri/common/controller/AbstractBaseEntityController.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.octri.common.domain.AbstractEntity;
+import org.octri.common.view.ViewUtils;
 import org.springframework.beans.propertyeditors.CustomDateEditor;
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -64,9 +65,9 @@ public abstract class AbstractBaseEntityController<T extends AbstractEntity, U e
 
 	public String list(Map<String, Object> model) {
 		addTemplateAttributes(model);
-		model.put("pageWebjars", new String[] { "datatables/js/jquery.dataTables.min.js",
-				"datatables/js/dataTables.bootstrap5.min.js" });
-		model.put("pageScripts", new String[] { "table-sorting.js" });
+		ViewUtils.addPageWebjar(model, "datatables/js/jquery.dataTables.min.js");
+		ViewUtils.addPageWebjar(model, "datatables/js/dataTables.bootstrap5.min.js");
+		ViewUtils.addPageScript(model, "table-sorting.js");
 		model.put("entity_list", getRepository().findAll());
 		return template("list");
 	}
@@ -79,6 +80,7 @@ public abstract class AbstractBaseEntityController<T extends AbstractEntity, U e
 
 	public String newEntity(Map<String, Object> model) {
 		addTemplateAttributes(model);
+		ViewUtils.addPageScript(model, "form-reset.js");
 		model.put("entity", newEntity());
 		return template("form");
 	}

--- a/src/main/java/org/octri/common/view/ViewUtils.java
+++ b/src/main/java/org/octri/common/view/ViewUtils.java
@@ -73,7 +73,7 @@ public class ViewUtils {
 			var newList = new ArrayList<String>(Arrays.asList(((String[]) existingArray)));
 			if (!newList.contains(value)) {
 				newList.add(value);
-				model.put(key, newList.toArray());
+				model.put(key, newList.toArray(new String[0]));
 			}
 		} else {
 			model.put(key, new String[] { value });

--- a/src/main/resources/static/assets/js/form-reset.js
+++ b/src/main/resources/static/assets/js/form-reset.js
@@ -1,0 +1,20 @@
+/**
+ * Ensure form is cleared when navigating through back button
+ */
+(function () {
+  'use strict';
+
+  window.addEventListener('pageshow', function (event) {
+    const forms = document.querySelectorAll('form');
+    for (const form of forms) {
+      // Clear the form
+      form.reset();
+
+      // Re-enable the submit button if needed
+      const submitButton = form.querySelector('[type="submit"]');
+      if (submitButton) {
+        submitButton.disabled = false;
+      }
+    }
+  });
+})();

--- a/src/main/resources/static/assets/js/table-sorting.js
+++ b/src/main/resources/static/assets/js/table-sorting.js
@@ -1,0 +1,17 @@
+/**
+ * Uses the Datatables javascript library to sort any tables with the `sorted` class. By default
+ * the first column (index 0) will be used for sorting, and the sort direction is ascending. These
+ * defaults can be overridden by providing data attributes of `data-column` and `data-orientation`.
+ * See the Datatables library documentation for more options: https://datatables.net
+ */
+$(function() {
+	const column = $(".sorted").attr("data-column") || 0;
+	const orientation = $(".sorted").attr("data-orientation") || "asc";
+
+	$(".sorted").DataTable({
+		order : [ [ column, orientation ] ],
+		paging : true,
+		searching : true,
+		info : true,
+	});
+});


### PR DESCRIPTION
# Overview

This takes the place of the previous PR (https://source.ohsu.edu/OCTRI-Apps/common-lib/pull/8). I removed the unnecessary webpack configuration. I also removed the webjar additions to the pom - this caused problems with styling in OPEN that I hadn't noticed before. The AbstractBaseEntityController does rely on datatables being present, so we should probably resolve this at some point.

## Issues

CIS-3209
CIS-3210
CIS-3211

[X] Added to CHANGELOG.md as 1.2.0 and will release after merge