### PR TITLE
CIS-3192 Add POM Metadata for Maven Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [unreleased]
+
+### Changed
+
+- Added POM metadata required for publishing to Maven Central. (CIS-3192)
 
 ## [1.3.0] - 2025-06-13
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
 	<packaging>jar</packaging>
 	<name>common_lib</name>
 	<description>OCTRI Common Library</description>
+	<url>https://source.ohsu.edu/OCTRI-Apps/common-lib</url>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
@@ -14,6 +15,25 @@
 		<relativePath />
 		<!-- lookup parent from repository -->
 	</parent>
+	<licenses>
+		<license>
+			<name>The 3-Clause BSD License</name>
+			<url>https://opensource.org/license/bsd-3-clause</url>
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>OCTRI Innovation Core</name>
+			<email>criapps@ohsu.edu</email>
+			<organization>Oregon Clinical &amp; Translational Research Institute (OCTRI)</organization>
+			<organizationUrl>https://www.ohsu.edu/octri</organizationUrl>
+		</developer>
+	</developers>
+	<scm>
+		<connection>scm:git:https://source.ohsu.edu/OCTRI-Apps/common-lib.git</connection>
+		<developerConnection>scm:git:https://source.ohsu.edu/OCTRI-Apps/common-lib.git</developerConnection>
+		<url>https://source.ohsu.edu/OCTRI-Apps/common-lib/tree/main</url>
+	</scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
# Overview

Add POM metadata required for publishing to Maven Central.

https://central.sonatype.org/publish/requirements/#required-pom-metadata

## Issues

CIS-3192

[X] Added to CHANGELOG.md

## Discussion

This will need to be adjusted when we make the repo public, but this at least ensures that the required fields are present.