### PR TITLE
CIS-3192 Change Developer Email

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	<developers>
 		<developer>
 			<name>OCTRI Innovation Core</name>
-			<email>criapps@ohsu.edu</email>
+			<email>octri-devops@ohsu.edu</email>
 			<organization>Oregon Clinical &amp; Translational Research Institute (OCTRI)</organization>
 			<organizationUrl>https://www.ohsu.edu/octri</organizationUrl>
 		</developer>


### PR DESCRIPTION
# Overview

Use DevOps email for the developer email in pom.xml to avoid spam going to the criapps list.

## Issues

CIS-3192

[X] Added to CHANGELOG.md - Covered by previous commit.
