### PR TITLE
CIS-3223: Add convenience methods for display of audit fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Added convenience methods to AbsractEntity for display and sort of audit fields.
+
 ## [1.4.0]
 
 ### Added

--- a/src/main/java/org/octri/common/domain/AbstractEntity.java
+++ b/src/main/java/org/octri/common/domain/AbstractEntity.java
@@ -1,6 +1,9 @@
 package org.octri.common.domain;
 
 import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import org.springframework.data.annotation.CreatedDate;
@@ -155,6 +158,46 @@ public abstract class AbstractEntity implements Serializable {
 	 */
 	public void setUpdatedBy(String updatedBy) {
 		this.updatedBy = updatedBy;
+	}
+
+	/**
+	 * Convenience method to get the creation date as a LocalDate.
+	 * 
+	 * @return
+	 */
+	public LocalDate getCreatedDate() {
+		return getCreatedAt().toInstant()
+				.atZone(ZoneId.systemDefault())
+				.toLocalDate();
+	};
+
+	/**
+	 * Convenience method to get the creation date as an ISO formatted string.
+	 * 
+	 * @return
+	 */
+	public String getCreatedDateIso() {
+		return getCreatedDate().format(DateTimeFormatter.ISO_DATE);
+	}
+
+	/**
+	 * Convenience method to get the last updated date as a LocalDate.
+	 * 
+	 * @return
+	 */
+	public LocalDate getUpdatedDate() {
+		return getUpdatedAt().toInstant()
+				.atZone(ZoneId.systemDefault())
+				.toLocalDate();
+	};
+
+	/**
+	 * Convenience method to get the last updated date as an ISO formatted string.
+	 * 
+	 * @return
+	 */
+	public String getUpdatedDateIso() {
+		return getUpdatedDate().format(DateTimeFormatter.ISO_DATE);
 	}
 
 	@Override


### PR DESCRIPTION
# Overview

Adds methods to AbstractEntity to convert audit fields to a LocalDate and an ISO string. This allows easier display and sorting in entity lists.

## Issues

CIS-3223

[X] Added to CHANGELOG.md