### PR TITLE
CIS-3339: Add support for Identifiable interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Added interfaces to support finding and selecting Identifiable resources that have a unique UUID
+
 ## [1.6.0]
 
 ### Added

--- a/src/main/java/org/octri/common/customizer/IdentifiableEntityFinder.java
+++ b/src/main/java/org/octri/common/customizer/IdentifiableEntityFinder.java
@@ -1,0 +1,14 @@
+package org.octri.common.customizer;
+
+import org.octri.common.domain.AbstractEntity;
+import org.octri.common.domain.Identifiable;
+
+/**
+ * Interface defining the methods for finding entities that are uniquely identified by a UUID.
+ */
+public interface IdentifiableEntityFinder<T extends AbstractEntity & Identifiable> {
+
+	Iterable<T> findAll();
+
+	T findByUuid(String uuid);
+}

--- a/src/main/java/org/octri/common/domain/Identifiable.java
+++ b/src/main/java/org/octri/common/domain/Identifiable.java
@@ -1,0 +1,10 @@
+package org.octri.common.domain;
+
+import org.octri.common.view.Labelled;
+
+/**
+ * Interface for classes that are uniquely identified by a UUID and have a label.
+ */
+public interface Identifiable extends UniquelyIdentified, Labelled {
+
+}

--- a/src/main/java/org/octri/common/domain/UniquelyIdentified.java
+++ b/src/main/java/org/octri/common/domain/UniquelyIdentified.java
@@ -1,0 +1,10 @@
+package org.octri.common.domain;
+
+/**
+ * Interface for classes that are uniquely identified by a UUID.
+ */
+public interface UniquelyIdentified {
+
+	public String getUuid();
+
+}

--- a/src/main/java/org/octri/common/view/IdentifiableOptionList.java
+++ b/src/main/java/org/octri/common/view/IdentifiableOptionList.java
@@ -1,0 +1,56 @@
+package org.octri.common.view;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.octri.common.customizer.IdentifiableEntityFinder;
+import org.octri.common.domain.AbstractEntity;
+import org.octri.common.domain.Identifiable;
+
+/**
+ * Convenience class for creating a lookup list from a class that is uniquely identified by a UUID and labelled.
+ */
+public class IdentifiableOptionList {
+
+	/**
+	 * Given an iterable of {@link Identifiable} objects and a selected object, provides a select options
+	 * that can be used directly by mustache templates for rendering.
+	 *
+	 * @param <T>
+	 *            a type that implements {@link Identifiable}
+	 * @param iter
+	 *            iterable collection
+	 * @param selected
+	 *            the current selection
+	 * @return a list of select options
+	 */
+	public static <T extends Identifiable> List<IdentifiableSelectOption<T>> fromAll(
+			Iterable<T> iter,
+			T selected) {
+		return StreamSupport.stream(iter.spliterator(), false)
+				.map(entity -> new IdentifiableSelectOption<T>(entity, selected))
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Given a {@link IdentifiableEntityFinder} and the UUID of the selected object, provides a list of
+	 * select
+	 * options that can be used directly by mustache templates for rendering.
+	 * 
+	 * @param <T>
+	 *            a type that extends {@link AbstractEntity} and implements {@link Identifiable}
+	 * @param repo
+	 *            a repository/finder for the entity type
+	 * @param selectedUuid
+	 *            the UUID of the selected object; may be null
+	 * @return a list of select options
+	 */
+	public static <T extends AbstractEntity & Identifiable> List<IdentifiableSelectOption<T>> fromAll(
+			IdentifiableEntityFinder<T> repo, String selectedUuid) {
+		var selected = (selectedUuid == null) ? null : repo.findByUuid(selectedUuid);
+		return StreamSupport.stream(repo.findAll().spliterator(), false)
+				.map(entity -> new IdentifiableSelectOption<T>(entity, selected))
+				.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/org/octri/common/view/IdentifiableSelectOption.java
+++ b/src/main/java/org/octri/common/view/IdentifiableSelectOption.java
@@ -1,0 +1,45 @@
+package org.octri.common.view;
+
+import java.util.Collection;
+
+import org.octri.common.domain.Identifiable;
+
+/**
+ * Used for UI select inputs for choices that implement {@link Identifiable} and the value is a UUID.
+ *
+ * @param<T>
+ */
+public class IdentifiableSelectOption<T extends Identifiable> extends SelectOption<T> {
+
+	/**
+	 * Constructor for single select.
+	 * 
+	 * @param choice
+	 *            - The choice to configure
+	 * @param selected
+	 *            - The selected item; may be null
+	 */
+	public IdentifiableSelectOption(T choice, T selected) {
+		super(choice, selected);
+		this.setLabel(choice.getLabel());
+		this.setValue(choice.getUuid());
+	}
+
+	/**
+	 * Constructor used for an option in a multi-select.
+	 *
+	 * @param choice
+	 *            - The choice to configure
+	 * @param selected
+	 *            - collection of selected items
+	 */
+	public IdentifiableSelectOption(T choice, Collection<T> selected) {
+		super(choice, selected);
+		this.setLabel(choice.getLabel());
+		this.setValue(choice.getUuid());
+	}
+
+	public String getUuid() {
+		return this.getChoice().getUuid();
+	}
+}


### PR DESCRIPTION
# Overview

This generalizes the classes used by the survey library to find Assignees and implement select lists for them. This concept will also be used by the notification library.

## Issues

CIS-3339

[X] Added to CHANGELOG.md