### PR TITLE
Vite Manifest Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for Vite.js assets, using the Vite manifest to ensure all dependencies of a given asset are loaded on the page.
+
 ## [2.0.1] - 2026-04-17
 
 ### Changed

--- a/src/main/java/org/octri/common/config/ViteManifestConfig.java
+++ b/src/main/java/org/octri/common/config/ViteManifestConfig.java
@@ -1,0 +1,70 @@
+package org.octri.common.config;
+
+import java.io.IOException;
+
+import org.octri.common.view.ViewUtils;
+import org.octri.common.view.ViteManifest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.ResourcePatternUtils;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Configuration for Vite manifest support.
+ */
+@Configuration
+@EnableConfigurationProperties(ViteManifestProperties.class)
+@ConditionalOnProperty(value = "octri.common.vite.enabled", havingValue = "true", matchIfMissing = false)
+public class ViteManifestConfig {
+
+	private final Logger log = LoggerFactory.getLogger(getClass());
+	private final ViteManifestProperties properties;
+	private final ResourceLoader resourceLoader;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param properties
+	 *            - configuration properties
+	 * @param resourceLoader
+	 *            - resource loader to use to load manifest files
+	 */
+	public ViteManifestConfig(ViteManifestProperties properties, ResourceLoader resourceLoader) {
+		log.info("Enabling Vite manifest support");
+		this.properties = properties;
+		this.resourceLoader = resourceLoader;
+	}
+
+	/**
+	 * Loads any Vite manifests found on the classpath, merges their contents, and adds the merged manifest to
+	 * {@link ViewUtils}.
+	 *
+	 * @throws IOException
+	 */
+	@PostConstruct
+	public void loadViteManifests() throws IOException {
+		var patternResolver = ResourcePatternUtils.getResourcePatternResolver(resourceLoader);
+		var resources = patternResolver.getResources(properties.getManifestPattern());
+
+		if (resources.length == 0) {
+			log.warn("No Vite manifest files found with pattern '{}'", properties.getManifestPattern());
+			return;
+		} else {
+			log.debug("Found {} Vite manifest file(s) with pattern '{}'", resources.length,
+					properties.getManifestPattern());
+		}
+
+		var mergedManifest = ViteManifest.fromResources(resources);
+		log.debug("Merged Vite manifest: {}", mergedManifest);
+		if (!mergedManifest.isEmpty()) {
+			log.info("Adding Vite manifest to ViewUtils.");
+			ViewUtils.useViteManifest(mergedManifest, properties.getEntrypointPrefix());
+		}
+	}
+
+}

--- a/src/main/java/org/octri/common/config/ViteManifestProperties.java
+++ b/src/main/java/org/octri/common/config/ViteManifestProperties.java
@@ -1,0 +1,84 @@
+package org.octri.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Vite manifest support.
+ */
+@ConfigurationProperties(prefix = "octri.common.vite")
+public class ViteManifestProperties {
+
+	/**
+	 * Whether to enable Vite manifest support. Defaults to false.
+	 */
+	private Boolean enabled = false;
+
+	/**
+	 * Pattern to use when searching for manifest resources. Defaults to "classpath:static/.vite/*.json".
+	 */
+	private String manifestPattern = "classpath:static/.vite/*.json";
+
+	/**
+	 * Prefix path where entrypoint scripts are stored, relative to the root of the repository. Used to look up
+	 * entrypoints in the manifest. Defaults to "src/main/resources/frontend/".
+	 */
+	private String entrypointPrefix = "src/main/resources/frontend/";
+
+	/**
+	 * Whether Vite manifest support is enabled.
+	 *
+	 * @return true if enabled, false otherwise
+	 */
+	public Boolean isEnabled() {
+		return enabled;
+	}
+
+	/**
+	 * Sets whether Vite manifest support is enabled.
+	 *
+	 * @param enabled
+	 *            true to enable Vite manifest support, false to disable it
+	 */
+	public void setEnabled(Boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	/**
+	 * Gets the pattern used to search for manifest resources.
+	 *
+	 * @return the currently-configured pattern
+	 */
+	public String getManifestPattern() {
+		return manifestPattern;
+	}
+
+	/**
+	 * Sets the pattern to use to search for manifest resources.
+	 *
+	 * @param manifestPattern
+	 *            the pattern to use
+	 */
+	public void setManifestPattern(String manifestPattern) {
+		this.manifestPattern = manifestPattern;
+	}
+
+	/**
+	 * Gets the path prefix of entrypoint scripts.
+	 *
+	 * @return the currently-configured prefix
+	 */
+	public String getEntrypointPrefix() {
+		return entrypointPrefix;
+	}
+
+	/**
+	 * Sets the path prefix of entrypoint scripts.
+	 *
+	 * @param entrypointPrefix
+	 *            the path prefix to use
+	 */
+	public void setEntrypointPrefix(String entrypointPrefix) {
+		this.entrypointPrefix = entrypointPrefix;
+	}
+
+}

--- a/src/main/java/org/octri/common/view/ViewUtils.java
+++ b/src/main/java/org/octri/common/view/ViewUtils.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.octri.common.domain.AbstractEntity;
 
@@ -15,28 +16,35 @@ import org.octri.common.domain.AbstractEntity;
  */
 public class ViewUtils {
 
-	/**
-	 * Model attribute used to store the names of JavaScript files attached to the page.
-	 */
+	public final static String PAGE_STYLES_ATTRIBUTE = "pageStyles";
 	public final static String PAGE_SCRIPT_ATTRIBUTE = "pageScripts";
-
-	/**
-	 * Model attribute used to store the names of JavaScript files attached to the page if the user is an admin.
-	 */
 	public final static String ADMIN_SCRIPT_ATTRIBUTE = "adminScripts";
-
-	/**
-	 * Model attribute used to store the names of Webjars attached to the page.
-	 */
 	public final static String PAGE_WEBJAR_ATTRIBUTE = "pageWebjars";
+	public final static String PAGE_MODULE_ATTRIBUTE = "pageModules";
+	public final static String PAGE_MODULE_PRELOAD_ATTRIBUTE = "pageModulePreloads";
+
+	private static ViteManifest viteManifest = ViteManifest.empty();
+	private static String entryPointPrefix = "";
 
 	/**
-	 * Utility method for creating a map object with a nested entity. Useful for
-	 * using entity components in different contexts.
+	 * Sets the manifest to use to look up assets processed by Vite.
+	 * 
+	 * @param manifest
+	 *            the Vite manifest to use
+	 * @param entryPointPrefix
+	 *            the path prefix to prepend when searching the manifest for a script
+	 */
+	public static void useViteManifest(ViteManifest manifest, String entryPointPrefix) {
+		ViewUtils.viteManifest = manifest;
+		ViewUtils.entryPointPrefix = entryPointPrefix;
+	}
+
+	/**
+	 * Utility method for creating a map object with a nested entity. Useful for using entity components in different
+	 * contexts.
 	 *
 	 * @param entity
-	 *            an entity
-	 * @return a map with an "entity" key that references the given entity
+	 * @return
 	 */
 	public static Map<String, Object> entityWrapper(AbstractEntity entity) {
 		Map<String, Object> wrapper = new HashMap<String, Object>();
@@ -48,58 +56,86 @@ public class ViewUtils {
 	 * Add the given script name to the model's pageScripts (see footer.mustache).
 	 *
 	 * @param model
-	 *            template model data
 	 * @param scriptName
-	 *            name of javascript to add to page scripts
 	 */
 	public static void addPageScript(Map<String, Object> model, String scriptName) {
-		addArrayProperty(model, PAGE_SCRIPT_ATTRIBUTE, scriptName);
+		if (viteManifest.hasEntry(entryPointPrefix + scriptName)) {
+			addManifestModule(model, scriptName);
+		} else {
+			addArrayProperty(model, PAGE_SCRIPT_ATTRIBUTE, scriptName);
+		}
 	}
 
 	/**
 	 * Add the given script name to the model's adminScripts (see footer.mustache)
 	 *
 	 * @param model
-	 *            template model data
 	 * @param scriptName
-	 *            name of javascript to add to admin page scripts
 	 */
 	public static void addAdminScript(Map<String, Object> model, String scriptName) {
 		addArrayProperty(model, ADMIN_SCRIPT_ATTRIBUTE, scriptName);
 	}
 
 	/**
-	 * Add the given Webjar to the model's pageWebjars (see footer.mustache)
-	 * 
+	 * Adds the given webjar name to the model's pageWebjars (see footer.mustache)
+	 *
 	 * @param model
-	 *            template model data
 	 * @param scriptName
-	 *            name of the Webjar script to add
 	 */
 	public static void addPageWebjar(Map<String, Object> model, String scriptName) {
 		addArrayProperty(model, PAGE_WEBJAR_ATTRIBUTE, scriptName);
 	}
 
 	/**
-	 * Add a value to a model's string array property.
+	 * Adds the given entrypoint and its dependencies to the module's asset arrays.
+	 *
+	 * @param model
+	 * @param entryFilename
+	 */
+	public static void addManifestModule(Map<String, Object> model, String entryFilename) {
+		var manifestKey = entryPointPrefix + entryFilename;
+		var entryChunk = viteManifest.getEntryPoint(manifestKey);
+		var importedChunks = viteManifest.getImportedChunks(manifestKey);
+
+		// collect css files from entry and imported chunks
+		var importedCss = new ArrayList<>();
+		importedCss.addAll(entryChunk.css());
+		importedChunks.stream().forEach(chunk -> importedCss.addAll(chunk.css()));
+		if (importedCss.size() > 0) {
+			addArrayProperty(model, PAGE_STYLES_ATTRIBUTE, importedCss.toArray(new String[0]));
+		}
+
+		// add the entrypoint module
+		addArrayProperty(model, PAGE_MODULE_ATTRIBUTE, entryChunk.file());
+
+		// preload imported modules
+		var importedModules = importedChunks.stream()
+				.map(ViteManifest.ViteManifestChunk::file)
+				.collect(Collectors.toList());
+		if (importedModules.size() > 0) {
+			addArrayProperty(model, PAGE_MODULE_PRELOAD_ATTRIBUTE, importedModules.toArray(new String[0]));
+		}
+	}
+
+	/**
+	 * Add one or more values to a model's string array property.
 	 *
 	 * @param model
 	 *            - model to modify
 	 * @param key
 	 *            - property name
-	 * @param value
-	 *            - value to add to the Array
+	 * @param values
+	 *            - values to add to the Array
 	 */
-	public static void addArrayProperty(Map<String, Object> model, String key, String value) {
+	public static void addArrayProperty(Map<String, Object> model, String key, String... values) {
 		var existingArray = model.get(key);
-		if (existingArray != null) {
-			var newList = new ArrayList<String>(Arrays.asList(((String[]) existingArray)));
+		var newList = existingArray != null ? new ArrayList<String>(Arrays.asList(((String[]) existingArray)))
+				: new ArrayList<String>();
+		for (var value : values) {
 			if (!newList.contains(value)) {
 				newList.add(value);
-				model.put(key, newList.toArray(new String[0]));
 			}
-		} else {
-			model.put(key, new String[] { value });
 		}
+		model.put(key, newList.toArray(new String[0]));
 	}
 }

--- a/src/main/java/org/octri/common/view/ViteManifest.java
+++ b/src/main/java/org/octri/common/view/ViteManifest.java
@@ -1,0 +1,135 @@
+package org.octri.common.view;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ViteManifest {
+
+	private static final Logger log = LoggerFactory.getLogger(ViteManifest.class);
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+
+	private final Map<String, ViteManifestChunk> chunkMap;
+
+	/**
+	 * Represents a chunk in a Vite manifest, which describes the attributes and dependencies of a single asset.
+	 *
+	 * @see <a href="https://vite.dev/guide/backend-integration">Vite Backend Integration Guide</a>
+	 */
+	public record ViteManifestChunk(String file, String name, String src, Boolean isEntry, Boolean isDynamicEntry,
+			List<String> imports, List<String> css, List<String> dynamicImports, List<String> assets) {
+
+		public ViteManifestChunk {
+			if (src == null) {
+				src = file;
+			}
+			if (name == null) {
+				name = file;
+			}
+			if (isEntry == null) {
+				isEntry = false;
+			}
+			if (isDynamicEntry == null) {
+				isDynamicEntry = false;
+			}
+			if (imports == null) {
+				imports = List.of();
+			}
+			if (css == null) {
+				css = List.of();
+			}
+			if (dynamicImports == null) {
+				dynamicImports = List.of();
+			}
+			if (assets == null) {
+				assets = List.of();
+			}
+		}
+	}
+
+	public static ViteManifest empty() {
+		return new ViteManifest(Map.of());
+	}
+
+	public static ViteManifest fromResources(Resource... resources) throws IOException {
+		var typeRef = new TypeReference<HashMap<String, ViteManifestChunk>>() {
+		};
+		var mergedManifest = new HashMap<String, ViteManifestChunk>();
+
+		for (var resource : resources) {
+			log.info("Loading Vite manifest from {}", resource.getURI());
+			var manifest = objectMapper.readValue(resource.getInputStream(), typeRef);
+			for (var entry : manifest.entrySet()) {
+				if (mergedManifest.containsKey(entry.getKey())) {
+					log.error("Duplicate entry '{}' found in manifest '{}'. Skipping.", entry.getKey(),
+							resource.getFilename());
+				}
+
+				mergedManifest.put(entry.getKey(), entry.getValue());
+			}
+		}
+
+		return new ViteManifest(mergedManifest);
+	}
+
+	private ViteManifest(Map<String, ViteManifestChunk> chunkMap) {
+		this.chunkMap = chunkMap;
+	}
+
+	public boolean isEmpty() {
+		return chunkMap.isEmpty();
+	}
+
+	public boolean hasEntry(String entryFilename) {
+		return chunkMap.containsKey(entryFilename);
+	}
+
+	public ViteManifestChunk getEntryPoint(String entryFilename) {
+		if (!chunkMap.containsKey(entryFilename)) {
+			throw new IllegalArgumentException("Entry '" + entryFilename + "' not found in manifest.");
+		}
+		var chunk = chunkMap.get(entryFilename);
+		if (!chunk.isEntry()) {
+			throw new IllegalArgumentException("Entry '" + entryFilename + "' is not an entry point.");
+		}
+		return chunk;
+	}
+
+	public List<ViteManifestChunk> getImportedChunks(String entryFilename) {
+		var entryChunk = getEntryPoint(entryFilename);
+		var visited = new HashSet<String>();
+		return getImportedChunks(entryChunk, visited);
+	}
+
+	public List<ViteManifestChunk> getImportedChunks(ViteManifestChunk chunk, Set<String> visited) {
+		var chunks = new ArrayList<ViteManifestChunk>();
+		for (var importName : chunk.imports()) {
+			if (visited.contains(importName)) {
+				continue;
+			}
+			visited.add(importName);
+			var importee = chunkMap.get(importName);
+			chunks.addAll(getImportedChunks(importee, visited));
+			chunks.add(importee);
+		}
+
+		return chunks;
+	}
+
+	@Override
+	public String toString() {
+		return "ViteManifest [chunkMap=" + chunkMap + "]";
+	}
+
+}

--- a/src/test/java/org/octri/common/view/ViewUtilsTest.java
+++ b/src/test/java/org/octri/common/view/ViewUtilsTest.java
@@ -1,0 +1,216 @@
+package org.octri.common.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.octri.common.domain.AbstractEntity;
+import org.springframework.core.io.ClassPathResource;
+
+public class ViewUtilsTest {
+
+	private class TestEntity extends AbstractEntity {
+	};
+
+	private Map<String, Object> model;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		var resource = new ClassPathResource("example-vite-manifest.json");
+		var manifest = ViteManifest.fromResources(resource);
+		ViewUtils.useViteManifest(manifest, "");
+		model = new HashMap<>();
+	}
+
+	public void useOctriManifest() throws Exception {
+		var resource = new ClassPathResource("example-octri-vite-manifest.json");
+		var manifest = ViteManifest.fromResources(resource);
+		ViewUtils.useViteManifest(manifest, "src/main/resources/frontend/");
+	}
+
+	@Test
+	public void testEntityWrapper() {
+		var entity = new TestEntity();
+		var wrapper = ViewUtils.entityWrapper(entity);
+		assertNotNull(wrapper, "It should return a wrapper map");
+		assertNotNull(wrapper.get("entity"), "It should contain an entry for the 'entity' key");
+		assertEquals(entity, wrapper.get("entity"), "The value should equal the input entity");
+	}
+
+	@Test
+	public void testAddPageScriptNotInManifest() {
+		ViewUtils.addPageScript(model, "table-sorting.js");
+		assertNotNull(model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE), "The page script array should be present");
+		var pageScripts = Arrays.asList((String[]) model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE));
+		assertTrue(pageScripts.contains("table-sorting.js"), "The page script array should contain the expected file");
+	}
+
+	@Test
+	public void testAddPageScriptWithEmptyManifest() {
+		ViewUtils.useViteManifest(ViteManifest.empty(), "");
+		ViewUtils.addPageScript(model, "views/foo.js");
+		assertNotNull(model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE), "The page script array should be present");
+		var pageScripts = Arrays.asList((String[]) model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE));
+		assertTrue(pageScripts.contains("views/foo.js"), "Should behave the same as files not in the manifest");
+	}
+
+	@Test
+	public void testAddPageScriptWithManifestEntrypointIsDelegated() {
+		assertTrue(model.size() == 0, "The model map should initially be empty");
+		// should be delegated to addManifestModule(...)
+		ViewUtils.addPageScript(model, "views/foo.js");
+		assertNull(model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE), "The page script array should not be present");
+		assertNotNull(model.get(ViewUtils.PAGE_MODULE_ATTRIBUTE), "The page modules array should be present");
+		assertNotNull(model.get(ViewUtils.PAGE_STYLES_ATTRIBUTE), "The page styles array should be present");
+		assertNotNull(model.get(ViewUtils.PAGE_MODULE_PRELOAD_ATTRIBUTE),
+				"The page module preloads array should be present");
+	}
+
+	@Test
+	public void testAddPageScriptWithManifestEntrypointUsesEntrypointPrefix() throws Exception {
+		useOctriManifest();
+		assertTrue(model.size() == 0, "The model map should initially be empty");
+		// should be delegated to addManifestModule(...)
+		ViewUtils.addPageScript(model, "managed-content.js");
+		assertNull(model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE), "The page script array should not be present");
+		assertNotNull(model.get(ViewUtils.PAGE_MODULE_ATTRIBUTE), "The page modules array should be present");
+	}
+
+	@Test
+	public void testAddAdminScript() {
+		ViewUtils.addAdminScript(model, "translation-management.js");
+		assertNotNull(model.get(ViewUtils.ADMIN_SCRIPT_ATTRIBUTE), "The admin script array should be present");
+		var adminScripts = Arrays.asList((String[]) model.get(ViewUtils.ADMIN_SCRIPT_ATTRIBUTE));
+		assertTrue(adminScripts.contains("translation-management.js"),
+				"The admin script array should contain the expected file");
+	}
+
+	@Test
+	public void testAddPageWebjar() {
+		ViewUtils.addPageWebjar(model, "datatables/js/dataTables.min.js");
+		assertNotNull(model.get(ViewUtils.PAGE_WEBJAR_ATTRIBUTE), "The page webjar array should be present");
+		var adminScripts = Arrays.asList((String[]) model.get(ViewUtils.PAGE_WEBJAR_ATTRIBUTE));
+		assertTrue(adminScripts.contains("datatables/js/dataTables.min.js"),
+				"The page webjars array should contain the expected path");
+	}
+
+	@Test
+	public void testAddManifestModuleAddsEntryModule() {
+		ViewUtils.addManifestModule(model, "views/foo.js");
+		var modules = Arrays.asList((String[]) model.get(ViewUtils.PAGE_MODULE_ATTRIBUTE));
+		assertTrue(modules.contains("assets/foo-BRBmoGS9.js"), "Module list should contain foo entry file");
+	}
+
+	@Test
+	public void testAddManifestModuleAddsCssFromEntry() {
+		ViewUtils.addManifestModule(model, "views/foo.js");
+		var styles = Arrays.asList((String[]) model.get(ViewUtils.PAGE_STYLES_ATTRIBUTE));
+		assertTrue(styles.contains("assets/foo-5UjPuW-k.css"), "Styles should include foo's own CSS");
+	}
+
+	@Test
+	public void testAddManifestModuleAddsCssFromImportedChunks() {
+		ViewUtils.addManifestModule(model, "views/foo.js");
+		var styles = Arrays.asList((String[]) model.get(ViewUtils.PAGE_STYLES_ATTRIBUTE));
+		assertTrue(styles.contains("assets/shared-ChJ_j-JJ.css"),
+				"Styles should include CSS from imported shared chunk");
+	}
+
+	@Test
+	public void testAddManifestModuleAddsPreloadsForImports() {
+		ViewUtils.addManifestModule(model, "views/foo.js");
+		var preloads = Arrays.asList((String[]) model.get(ViewUtils.PAGE_MODULE_PRELOAD_ATTRIBUTE));
+		assertTrue(preloads.contains("assets/shared-B7PI925R.js"), "Preloads should include the imported shared chunk");
+	}
+
+	@Test
+	public void testAddManifestModuleNoOwnCss() {
+		ViewUtils.addManifestModule(model, "views/bar.js");
+		var styles = Arrays.asList((String[]) model.get(ViewUtils.PAGE_STYLES_ATTRIBUTE));
+		assertFalse(styles.contains("assets/bar-gkvgaI9m.js"), "Styles should not include bar's module file");
+		assertTrue(styles.contains("assets/shared-ChJ_j-JJ.css"),
+				"Styles should include CSS from imported shared chunk");
+	}
+
+	@Test
+	public void testAddManifestModuleThrowsForUnknownEntry() {
+		assertThrows(IllegalArgumentException.class, () -> ViewUtils.addManifestModule(model, "nonexistent.js"),
+				"Unknown entry point should throw IllegalArgumentException");
+	}
+
+	@Test
+	public void testAddManifestModulePrependsEntrypointPrefix() throws Exception {
+		useOctriManifest();
+		ViewUtils.addManifestModule(model, "managed-content.js");
+		var modules = Arrays.asList((String[]) model.get(ViewUtils.PAGE_MODULE_ATTRIBUTE));
+		assertTrue(modules.contains("assets/js/managed-content-CKqkE5xz.js"),
+				"The entrypoint prefix should have been prepended to the filename when looking up the chunk");
+	}
+
+	@Test
+	public void testAddArrayPropertySingleValue() {
+		ViewUtils.addArrayProperty(model, ViewUtils.PAGE_SCRIPT_ATTRIBUTE, "example.js");
+		assertNotNull(model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE), "The page script array should be present");
+		var pageScripts = Arrays.asList((String[]) model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE));
+		assertEquals(1, pageScripts.size(), "There should be one value");
+		assertEquals("example.js", pageScripts.get(0), "The expected value should be present");
+	}
+
+	@Test
+	public void testAddArrayPropertyMultipleValues() {
+		ViewUtils.addArrayProperty(model, ViewUtils.PAGE_SCRIPT_ATTRIBUTE, "a.js", "b.js");
+		assertNotNull(model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE), "The page script array should be present");
+		var pageScripts = Arrays.asList((String[]) model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE));
+		assertEquals(2, pageScripts.size(), "There should be two values");
+		assertEquals("a.js", pageScripts.get(0), "The expected values should be present");
+		assertEquals("b.js", pageScripts.get(1), "The expected values should be present");
+	}
+
+	@Test
+	public void testAddArrayPropertyDeduplicatesValuesWhenCreatingArray() {
+		ViewUtils.addArrayProperty(model, ViewUtils.PAGE_SCRIPT_ATTRIBUTE, "a.js", "b.js", "a.js");
+		assertNotNull(model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE), "The page script array should be present");
+		var pageScripts = Arrays.asList((String[]) model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE));
+		assertEquals(2, pageScripts.size(), "There should only be two values");
+		assertEquals("a.js", pageScripts.get(0), "The expected values should be present");
+		assertEquals("b.js", pageScripts.get(1), "The expected values should be present");
+	}
+
+	@Test
+	public void testAddArrayPropertyDeduplicatesValuesWhenAppending() {
+		ViewUtils.addArrayProperty(model, ViewUtils.PAGE_SCRIPT_ATTRIBUTE, "a.js", "b.js");
+		assertNotNull(model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE), "The page script array should be present");
+		var pageScripts = Arrays.asList((String[]) model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE));
+		assertEquals(2, pageScripts.size(), "There should be two values");
+		assertEquals("a.js", pageScripts.get(0), "The expected values should be present");
+		assertEquals("b.js", pageScripts.get(1), "The expected values should be present");
+
+		ViewUtils.addArrayProperty(model, ViewUtils.PAGE_SCRIPT_ATTRIBUTE, "a.js");
+		pageScripts = Arrays.asList((String[]) model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE));
+		assertEquals(2, pageScripts.size(), "There should still be two values");
+		assertEquals("a.js", pageScripts.get(0), "The expected values should still be present");
+		assertEquals("b.js", pageScripts.get(1), "The expected values should still be present");
+	}
+
+	@Test
+	public void testAddArrayPropertyAppendsToExistingValues() {
+		ViewUtils.addArrayProperty(model, ViewUtils.PAGE_SCRIPT_ATTRIBUTE, "a.js", "b.js");
+		assertNotNull(model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE), "The page script array should be present");
+		var pageScripts = Arrays.asList((String[]) model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE));
+		assertEquals(2, pageScripts.size(), "There should be two values");
+
+		ViewUtils.addArrayProperty(model, ViewUtils.PAGE_SCRIPT_ATTRIBUTE, "c.js");
+		pageScripts = Arrays.asList((String[]) model.get(ViewUtils.PAGE_SCRIPT_ATTRIBUTE));
+		assertEquals("c.js", pageScripts.get(2), "The new value should be appended to the array");
+	}
+
+}

--- a/src/test/java/org/octri/common/view/ViteManifestTest.java
+++ b/src/test/java/org/octri/common/view/ViteManifestTest.java
@@ -1,0 +1,76 @@
+package org.octri.common.view;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+public class ViteManifestTest {
+
+	private static Resource manifestResource;
+	private ViteManifest sharedManifest;
+
+	@BeforeAll
+	public static void setup() {
+		manifestResource = new ClassPathResource("example-vite-manifest.json");
+	}
+
+	@BeforeEach
+	public void loadManifest() throws Exception {
+		sharedManifest = ViteManifest.fromResources(manifestResource);
+	}
+
+	@Test
+	public void testEmptyManifest() {
+		var manifest = ViteManifest.empty();
+		assertTrue(manifest.isEmpty(), "Empty manifest should be empty");
+	}
+
+	@Test
+	public void testLoadManifest() throws Exception {
+		assertTrue(!sharedManifest.isEmpty(), "Manifest should not be empty");
+	}
+
+	@Test
+	public void testHasEntry() {
+		assertTrue(sharedManifest.hasEntry("views/foo.js"),
+				"Manifest should contain foo.js entry");
+		assertFalse(sharedManifest.hasEntry("views/nonexistent.js"),
+				"Manifest should not contain nonexistent.js entry");
+	}
+
+	@Test
+	public void testGetEntryPoint() {
+		var chunk = sharedManifest.getEntryPoint("views/foo.js");
+		assertTrue(chunk != null, "Chunk for foo.js should not be null");
+		assertTrue(chunk.src().equals("views/foo.js"), "Chunk src should be views/foo.js");
+		assertTrue(chunk.file().equals("assets/foo-BRBmoGS9.js"), "Chunk file should be assets/foo-BRBmoGS9.js");
+	}
+
+	@Test
+	public void testGetMissingEntryPoint() {
+		assertThrows(IllegalArgumentException.class, () -> sharedManifest.getEntryPoint("views/nonexistent.js"),
+				"Getting a non-existent entry point should throw IllegalArgumentException");
+	}
+
+	@Test
+	public void testGetNonEntryPoint() {
+		assertThrows(IllegalArgumentException.class, () -> sharedManifest.getEntryPoint("baz.js"),
+				"Getting a non-entry point should throw IllegalArgumentException");
+	}
+
+	@Test
+	public void testGetImportedChunks() {
+		var expectedFooImport = "assets/shared-B7PI925R.js";
+		var importedChunks = sharedManifest.getImportedChunks("views/foo.js");
+		assertTrue(importedChunks.size() == 1, "foo.js should have 1 imported chunks");
+		var importFiles = importedChunks.stream().map(chunk -> chunk.file()).toList();
+		assertTrue(importFiles.contains(expectedFooImport), "Imported chunks should include " + expectedFooImport);
+	}
+
+}

--- a/src/test/resources/example-octri-vite-manifest.json
+++ b/src/test/resources/example-octri-vite-manifest.json
@@ -1,0 +1,8 @@
+{
+  "src/main/resources/frontend/managed-content.js": {
+    "file": "assets/js/managed-content-CKqkE5xz.js",
+    "name": "managed-content",
+    "src": "src/main/resources/frontend/managed-content.js",
+    "isEntry": true
+  }
+}

--- a/src/test/resources/example-vite-manifest.json
+++ b/src/test/resources/example-vite-manifest.json
@@ -1,0 +1,43 @@
+{
+  "_shared-B7PI925R.js": {
+    "file": "assets/shared-B7PI925R.js",
+    "name": "shared",
+    "css": [
+      "assets/shared-ChJ_j-JJ.css"
+    ]
+  },
+  "_shared-ChJ_j-JJ.css": {
+    "file": "assets/shared-ChJ_j-JJ.css",
+    "src": "_shared-ChJ_j-JJ.css"
+  },
+  "baz.js": {
+    "file": "assets/baz-B2H3sXNv.js",
+    "name": "baz",
+    "src": "baz.js",
+    "isDynamicEntry": true
+  },
+  "views/bar.js": {
+    "file": "assets/bar-gkvgaI9m.js",
+    "name": "bar",
+    "src": "views/bar.js",
+    "isEntry": true,
+    "imports": [
+      "_shared-B7PI925R.js"
+    ],
+    "dynamicImports": [
+      "baz.js"
+    ]
+  },
+  "views/foo.js": {
+    "file": "assets/foo-BRBmoGS9.js",
+    "name": "foo",
+    "src": "views/foo.js",
+    "isEntry": true,
+    "imports": [
+      "_shared-B7PI925R.js"
+    ],
+    "css": [
+      "assets/foo-5UjPuW-k.css"
+    ]
+  }
+}


### PR DESCRIPTION
# Overview

Add support for assets processed with Vite to `ViewUtils`.

## Issues

N/A

[X] Added to CHANGELOG.md

## Discussion

Webpack ate a bunch of my time today, which convinced me to get out a PR for this branch. My goal here was to extend the `ViewUtils` class to allow using [Vite with a production-ready configuration](https://vite.dev/guide/backend-integration) that generates hashed filenames, but I didn't want to change the behavior for existing applications. To that end, a feature flag is required to enable the Vite manifest processing, and if a Vite manifest isn't present or a file isn't found in the manifest, the methods in `ViewUtils` behave exactly the same as before.

Pros:

* New API is opt-in, and there are no breaking changes.
* Automatically loads dependencies, so you don't have to remember to load `vendor.js` (for example).
* Can merge multiple manifest files, opening up the possibility of migrating libraries to Vite as well.

Cons:

* The code is somewhat complicated. 
* It adds state to `ViewUtils`. I made that compromise to avoid changing the API, but I'm not entirely happy with it.
 
If this ultimately isn't something that we want to merge, I can find a simpler way of integrating Vite into our Maven builds, starting with the FHIR sandbox.