### PR TITLE
Revert "Bump opencsv from 5.11.1 to 5.12.0 (#23)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Dependencies
+
 - Bump `poi.version` from 5.4.1 to 5.5.1 ([#35](https://github.com/OHSU-OCTRI/common-lib/pull/35))
 - Bump `softprops/action-gh-release` from 2 to 3 ([#45](https://github.com/OHSU-OCTRI/common-lib/pull/45))
 - Bump `org.webjars:datatables` from 2.3.7 to 2.3.8 ([#47](https://github.com/OHSU-OCTRI/common-lib/pull/47))
-- Bump `org.springframework.boot:spring-boot-starter-parent` from 3.5.11 to 3.5.14 ([#48](https://github.com/OHSU-OCTRI/common-lib/pull/48))
-- Bump `com.opencsv:opencsv` from 5.11.1 to 5.12.0 ([#23](https://github.com/OHSU-OCTRI/common-lib/pull/23))
 - Bump `org.springframework.boot:spring-boot-starter-parent` from 3.5.11 to 3.5.14 ([#48](https://github.com/OHSU-OCTRI/common-lib/pull/48))
 
 ## [2.1.0] - 2026-05-28

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<opencsv.version>5.12.0</opencsv.version>
+		<opencsv.version>5.11.1</opencsv.version>
 		<poi.version>5.5.1</poi.version>
 	</properties>
 	<distributionManagement>


### PR DESCRIPTION
This reverts commit 7cc9b3d94ed67892c439fe01cd1bcaffce5e9645, reversing changes made to 8c4744cb124fc9b25742335869538d3e03f8e18a.