### PR TITLE
CIS-3773 Update workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,77 +1,16 @@
 ---
-name: Build
+name: Build and publish
 on:
   push:
     branches:
-      - '**'
-  pull_request:
-    types:
-      - opened
-      - edited
+      - 'main'
   workflow_dispatch:
 
 jobs:
   build-java-source:
-    name: Build jar files
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Java environment for GitHub Packages
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: maven
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-
-      - name: Build and test
-        run: mvn package
-
-      - name: Get version from POM
-        id: get-version
-        run: |
-          version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "version=$version" >> $GITHUB_ENV
-
-      - name: Publish to GitHub Packages
-        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
-        run: mvn deploy -DskipTests -Pci
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-
-  publish:
-    name: Publish to Maven Central
-    needs: build-java-source
-    if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Java environment for Maven Central
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: maven
-          server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-
-      - name: Publish release to Maven Central
-        run: mvn deploy -DskipTests -Pci,publish
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+    name: Build jar and test
+    uses: OHSU-OCTRI/shared-workflows/.github/workflows/java-build.yaml@main
+    with:
+      java_version: '17'
+      publish_to_github_packages: ${{ github.ref == 'refs/heads/main' || github.ref_type == 'tag' }}
+    secrets: inherit

--- a/.github/workflows/dependabot-changelog-update.yaml
+++ b/.github/workflows/dependabot-changelog-update.yaml
@@ -1,33 +1,18 @@
 name: Add Dependabot updates to CHANGELOG.md
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-      - labeled
-      - unlabeled
+  workflow_dispatch:
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - synchronize
+  #     - reopened
+  #     - ready_for_review
+  #     - labeled
+  #     - unlabeled
 
 jobs:
   update_changelog:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Add Dependabot changes to CHANGELOG.md
-        uses: dangoslen/dependabot-changelog-helper@v4.3.0
-        with:
-          activationLabels: dependencies
-          changelogPath: './CHANGELOG.md'
-          dependencyTool: dependabot
-
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7.1.0
-        with:
-          commit_message: Add Dependabot update to CHANGELOG.md
+    name: Add Dependabot updates to CHANGELOG.md
+    uses: OHSU-OCTRI/shared-workflows/.github/workflows/dependabot-changelog-update.yaml@main
+    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,71 +15,9 @@ on:
 jobs:
   prepare-release:
     name: Prepare release
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: write
-      packages: write
-
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v6
-
-    - name: Set up Java build environment
-      uses: actions/setup-java@v5
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-        cache: 'maven'
-
-    - name: Set up Git
-      run: |
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --global user.name "github-actions[bot]"
-
-    - name: Update CHANGELOG.md
-      id: update_changelog
-      uses: thomaseizinger/keep-a-changelog-new-release@3.1.0
-      with:
-        tag: v${{ inputs.version }}
-
-    - name: Commit CHANGELOG.md
-      run: |
-        git add CHANGELOG.md
-        git commit -m "Add version ${{ inputs.version }} to CHANGELOG.md"
-
-    - name: Prepare Maven release
-      run: |
-        mvn -B \
-          -Darguments=-DskipTests \
-          -DautoVersionSubmodules=true \
-          -DreleaseVersion=${{ inputs.version }} \
-          -DscmReleaseCommitComment="Release version ${{ inputs.version }}" \
-          -DdevelopmentVersion=${{ inputs.development_version }}-SNAPSHOT \
-          -DscmDevelopmentCommitComment="Next development version - ${{ inputs.development_version }}" \
-          -Dtag=v${{ inputs.version }} \
-          -Dusername=${{ github.actor }} \
-          -Dpassword=${{ secrets.GITHUB_TOKEN }} \
-          release:prepare
-
-    - name: Create GitHub release
-      uses: softprops/action-gh-release@v3
-      with:
-        body: ${{ steps.update_changelog.outputs.release-notes }}
-        draft: false
-        prerelease: false
-        name: ${{ inputs.version }}
-        tag_name: v${{ inputs.version }}
-        generate_release_notes: false
-
-    - name: Build release artifacts
-      run: |
-        gh workflow run build.yaml --ref v${{ inputs.version }}
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Build snapshot artifacts
-      run: |
-        gh workflow run build.yaml --ref main
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: OHSU-OCTRI/shared-workflows/.github/workflows/java-release.yaml@main
+    with:
+      version: ${{ inputs.version }}
+      development_version: ${{ inputs.development_version }}
+      java_version: '17'
+    secrets: inherit

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,0 +1,21 @@
+---
+name: Build and test
+on:
+  push:
+    branches-ignore:
+      - 'main'
+      - 'dependabot/**'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  build-java-source:
+    name: Build jar and test
+    uses: OHSU-OCTRI/shared-workflows/.github/workflows/java-test-build.yaml@main
+    with:
+      java_version: '17'
+    # Does not inherit secrets due to security changes in automated workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use shared GitHub Actions workflows (CIS-3773)
+- Create a test build workflow to handle PRs (CIS-3773)
+
 ### Dependencies
 
 - Bump `spring-boot-starter-parent` from 3.5.14 to 3.5.15


### PR DESCRIPTION
# Overview

Update existing workflows to use the organization's shared workflows:

* build.yaml
* dependabot-changelog-update.yaml
* release.yaml

Additionally, split the build workflow into separate publication and testing workflows, so that PRs can run the test build without needed secrets. Also, refined the build trigger rules to reduce redundant workflow runs.

## Issues

[CIS-3773](https://jirabp.ohsu.edu/browse/CIS-3773)

[x] Added to CHANGELOG.md